### PR TITLE
Replace 'asfarray' with 'asarray' for numpy 2.0 compatibility

### DIFF
--- a/fatpack/endurance.py
+++ b/fatpack/endurance.py
@@ -17,7 +17,7 @@ def ensure_array(method):
         if x_is_float_or_int:
             xm = np.array([x])
         else:
-            xm = np.asfarray(x)
+            xm = np.asarray(x, dtype=float)
         ym = method(self, xm)
         if x_is_float_or_int:
             ym = ym[0]
@@ -123,7 +123,7 @@ class AbstractEnduranceCurve(object):
 
         """
 
-        Sr = np.asfarray(S)
+        Sr = np.asarray(S, dtype=float)
         shape = Sr.shape
         if len(shape) == 1:
             miner_sum = np.sum(1. / self.get_endurance(Sr))


### PR DESCRIPTION
Replace the use of `numpy.asfarray` (removed in numpy 2.0) with `numpy.asarray` with the `dtype=float` argument.

The three example notebooks and `example.py` script run to completion with this change, but I did not validate their results.

Fixes #24 